### PR TITLE
Fix exclude_missing

### DIFF
--- a/R/ivo_tables.R
+++ b/R/ivo_tables.R
@@ -33,7 +33,9 @@ ivo_excl_missing <- function(df, exclude_missing = FALSE, missing_string = "(Mis
         df[is.na(df[[i]]),i] <- "6049122418972891471204127890512XY"
         df[[i]] <- factor(df[[i]], levels = c(levs, "6049122418972891471204127890512XY"), labels = c(levs, missing_string))
       } else if(sum(is.na(df[[i]]))>0) { df[is.na(df[[i]]), i] <- missing_string }
-    }}
+    }} else {
+      df <- na.omit(df)
+    }
   return(df)
 }
 

--- a/R/ivo_tables.R
+++ b/R/ivo_tables.R
@@ -39,9 +39,8 @@ ivo_excl_missing <- function(df, exclude_missing = FALSE, missing_string = "(Mis
 
 ivo_num_sum <- function(x)
 {
-  suppressWarnings(x <- sum(as.numeric(unlist(gsub("\\s+", "", x)))))
+  suppressWarnings(x <- format(sum(as.numeric(unlist(gsub("\\s+", "", x)))), big.mark = " "))
   x[is.na(x)] <- "-"
-  if (grepl("^\\d+$", x)) x <- paste0(format(as.numeric(x), big.mark = " "))
   return(x)
 }
 


### PR DESCRIPTION
This should make exclude_missing work properly. Tested briefly. 
Also cleaned up the previous fix for big.mark on sums. 

Closes #13.