### PR TITLE
Fix variable name not found 

### DIFF
--- a/R/ivo_tables.R
+++ b/R/ivo_tables.R
@@ -128,11 +128,8 @@ ivo_tab3_step1 <- function(df, v1, v3, v4, exclude_missing, missing_string)
   df |> dplyr::select({{v4}}, {{v1}}, {{v3}}) |>
     ivo_excl_missing(exclude_missing, missing_string) |>
     stats::ftable(exclude=NULL) |>
-    base::data.frame() #|>
-    # `colnames<-`(c({{v1}}, {{v3}}, {{v4}}, "Freq")) -> df
-    # df[order(df[,1]),]
-    #`colnames<-`(c({{v1}}, {{v3}}, {{v4}}, "Freq")) |>
-    #dplyr::arrange(.data[[v4]])
+    base::data.frame() |>
+    `colnames<-`(c({{v1}}, {{v3}}, {{v4}}, "Freq"))
 }
 
 ivo_tab3_step2 <- function(df, v1, v3, v4, extra_header, colsums, rowsums, percent_by, remove_zero_rows, sums_string)
@@ -185,10 +182,9 @@ ivo_tab4_step1 <- function(df, v1, v2, v3, v4, exclude_missing, missing_string)
   df |> dplyr::select({{v4}}, {{v1}}, {{v2}}, {{v3}}) |>
     ivo_excl_missing(exclude_missing, missing_string) |>
     stats::ftable(exclude=NULL) |>
-    base::data.frame() #|>
-    #`colnames<-`(c({{v1}}, {{v2}}, {{v3}}, {{v4}}, "Freq"))
-  # -> df
-  #   df[do.call(order, list(df[,1], df[,2])),]
+    base::data.frame() |>
+    `colnames<-`(c({{v1}}, {{v2}}, {{v3}}, {{v4}}, "Freq"))
+
 }
 
 ivo_tab4_step2 <- function(df, v1, v2, v3, v4, extra_header, colsums, rowsums, percent_by, remove_zero_rows, sums_string)


### PR DESCRIPTION
I reintroduced `colnames()` for three-way and four-way tables so that spaces in variable names won't cause an error. 
This should do for now, though I really want to write some proper tests at some point. Probably a good idea to do that before any larger rewrite. :)

Fixes #25.